### PR TITLE
Renamed tab titles to appear uniform

### DIFF
--- a/attempt2atindex.html
+++ b/attempt2atindex.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A layout example that shows off a responsive product landing page.">
 
-    <title>Landing Page &ndash; Layout Examples &ndash; Pure</title>
+    <title>R.E.A.F</title>
 
 
 

--- a/home.html
+++ b/home.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-    <title>purecss &ndash; Layout Examples &ndash; Pure</title>
+    <title>R.E.A.F &ndash; Home</title>
 
 
 

--- a/home2.html
+++ b/home2.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-    <title>purecss &ndash; Layout Examples &ndash; Pure</title>
+    <title>R.E.A.F &ndash; Home</title>
 
 
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A layout example that shows off a responsive product landing page.">
 
-    <title>R.E.A.F website</title>
+    <title>R.E.A.F</title>
 
 
 

--- a/news.html
+++ b/news.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-    <title>Responsive Side Menu &ndash; Layout Examples &ndash; Pure</title>
+    <title>R.E.A.F &ndash; News</title>
 
 
 

--- a/team.html
+++ b/team.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="A layout example with a side menu that hides on mobile, just like the Pure website.">
 
-    <title>REAF Website</title>
+    <title>R.E.A.F &ndash; Team</title>
 
 
 


### PR DESCRIPTION
Naming convention should be clean and the same between all tabs, in this case I used
`R.E.A.F &ndash; tab_name`
